### PR TITLE
add constraint for transient dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
   "license": "GPL-3.0-only",
   "require": {
     "firebase/php-jwt": "^5.0",
-    "gree/jose": "^2.2.1"
+    "gree/jose": "^2.2.1",
+    "phpseclib/phpseclib": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
A transient dependency declares support for `phpseclib/phpseclib:>=2.0.0`, however 3.x is incompatible with 2.x, causing this library to break.